### PR TITLE
Fix select input options error

### DIFF
--- a/includes/admin/class-alg-wc-pif-per-product-metabox.php
+++ b/includes/admin/class-alg-wc-pif-per-product-metabox.php
@@ -59,7 +59,7 @@ if ( ! class_exists( 'Alg_WC_PIF_Per_Product_Metabox' ) ) :
 					$option_id = ALG_WC_PIF_ID . '_' . $option['id'] . '_local_' . $i;
 
 					if ( isset( $_POST[ $option_id ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-						update_post_meta( $post_id, '_' . $option_id, sanitize_text_field( wp_unslash( $_POST[ $option_id ] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
+						update_post_meta( $post_id, '_' . $option_id, $_POST[ $option_id ]  ); // phpcs:ignore
 					} elseif ( 'checkbox' === $option['type'] ) {
 						update_post_meta( $post_id, '_' . $option_id, 'no' );
 					}


### PR DESCRIPTION
The select options were saved in single line and displayed as one option on frontend due to sanitization.