### PR TITLE
Fix #100

### DIFF
--- a/includes/class-alg-wc-pif-tracking.php
+++ b/includes/class-alg-wc-pif-tracking.php
@@ -64,7 +64,7 @@ if ( ! class_exists( 'Pif_Tracking_Functions' ) ) :
 
 			wp_enqueue_script(
 				'pif_ts_dismiss_notice',
-				plugins_url( '/includes/js/tyche-dismiss-tracking-notice.js', __FILE__ ),
+				plugins_url( '/js/tyche-dismiss-tracking-notice.js', __FILE__ ),
 				'',
 				ALG_WC_PIF_VERSION,
 				false


### PR DESCRIPTION
The `tyche-dismiss-tracking-notice.js` file was throwing a 404 due to a mistake in the code. This fix corrects the mistake so that the file is loaded properly.